### PR TITLE
Add CSP note to Stripe SCA Payment confirmations

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,12 @@ If you'd like to change the views of the payment confirmation page, you can inst
 
 [<img src="https://d1jfzjx68gj8xs.cloudfront.net/items/2s3Z0J3Z3b1J1v2K2O1a/Screen%20Shot%202019-10-10%20at%2012.56.32%20PM.png?X-CloudApp-Visitor-Id=51470" alt="Stripe SCA Payment Confirmation" style="zoom: 25%;" />](https://d1jfzjx68gj8xs.cloudfront.net/items/2s3Z0J3Z3b1J1v2K2O1a/Screen%20Shot%202019-10-10%20at%2012.56.32%20PM.png)
 
+If you use the default views for payment confirmations, and also have a Content Security Policy in place for your application, make sure to add the following domains to their respective configurations in your `content_security_policy.rb` (otherwise these views won't load properly):
+
+* `style_src`: `https://unpkg.com`
+* `script_src`: `https://cdn.jsdelivr.net` and `https://js.stripe.com`
+* `frame_src`: `https://js.stripe.com`
+
 #### Background jobs
 
 If a user's email is updated and they have a `processor_id` set, Pay will enqueue a background job (EmailSyncJob) to sync the email with the payment processor.


### PR DESCRIPTION
When apps have a Content Security Policy in place, the domains for the Stripe and Vue scripts, styles and frames should be added to the CSP in order for the payment confirmation pages to work. 

Having this note in the README would be helpful.